### PR TITLE
Revert "Added API connections to web app"

### DIFF
--- a/Jejakra-web/src/hooks/useAppointments.js
+++ b/Jejakra-web/src/hooks/useAppointments.js
@@ -1,125 +1,143 @@
 /**
  * Custom Hook: useAppointments
- * Manages appointment data, filtering, and actions with live API calls
+ * Manages appointment data, filtering, and actions
  */
 
 import { useState, useMemo, useCallback } from 'react'
-import { appointmentApi, patientApi } from '../services/api'
 import { formatDate } from '../utils/formatters'
+
+// Initial mock appointment data
+const initialAppointments = [
+  // Today's appointments
+  { id: 1, patientName: 'Ahmad bin Abdullah', appointmentType: 'Consultation', sessionType: 'TREATMENT', date: '2020-03-25', time: '8:00 AM', visitType: 'In-person', status: 'No show', notes: 'NOTE', isToday: true },
+  { id: 2, patientName: 'Siti Nurhaliza', appointmentType: 'Follow Up', sessionType: 'INTAKE INTERVIEW', date: '2020-03-25', time: '9:30 AM', visitType: 'Virtual', status: 'Ongoing', notes: '', isToday: true },
+  { id: 3, patientName: 'Muhammad Faiz', appointmentType: 'Routine Check-up', sessionType: 'TREATMENT', date: '2020-03-25', time: '11:00 AM', visitType: 'Virtual', status: 'Scheduled', notes: '', isToday: true },
+  { id: 4, patientName: 'Aisyah Putri', appointmentType: 'Consultation', sessionType: 'TREATMENT', date: '2020-03-25', time: '12:30 PM', visitType: 'In-person', status: 'Completed', notes: 'NOTE', isToday: true },
+  { id: 5, patientName: 'Rizal bin Hassan', appointmentType: 'Follow Up', sessionType: 'FOLLOW UP', date: '2020-03-25', time: '3:00 PM', visitType: 'Virtual', status: 'Scheduled', notes: '', isToday: true },
+  { id: 6, patientName: 'Nadia Tan', appointmentType: 'Routine Check-up', sessionType: 'TREATMENT', date: '2020-03-25', time: '4:30 PM', visitType: 'In-person', status: 'Cancelled', notes: 'NOTE', isToday: true },
+  // Upcoming appointments
+  { id: 7, patientName: 'Nurul Ain', appointmentType: 'Consultation', sessionType: 'TREATMENT', date: '2020-03-27', time: '8:00 AM', visitType: 'Virtual', status: 'Scheduled', notes: '', isToday: false },
+  { id: 8, patientName: 'Amirul Haziq', appointmentType: 'Follow Up', sessionType: 'TREATMENT', date: '2020-03-27', time: '9:30 AM', visitType: 'In-person', status: 'Scheduled', notes: 'NOTE', isToday: false },
+  { id: 9, patientName: 'Fatimah Zahra', appointmentType: 'Routine Check-up', sessionType: 'FINAL SESSION', date: '2020-03-27', time: '11:00 AM', visitType: 'Virtual', status: 'Scheduled', notes: '', isToday: false },
+  { id: 10, patientName: 'Hafiz Rahman', appointmentType: 'Consultation', sessionType: 'FOLLOW UP', date: '2020-03-27', time: '3:00 PM', visitType: 'In-person', status: 'Scheduled', notes: '', isToday: false },
+  { id: 11, patientName: 'Sarah Abdullah', appointmentType: 'Follow Up', sessionType: 'TREATMENT', date: '2020-03-28', time: '8:00 AM', visitType: 'Virtual', status: 'Scheduled', notes: 'NOTE', isToday: false },
+  { id: 12, patientName: 'Zulkifli bin Omar', appointmentType: 'Consultation', sessionType: 'INTAKE INTERVIEW', date: '2020-03-28', time: '11:00 AM', visitType: 'In-person', status: 'Scheduled', notes: '', isToday: false },
+  { id: 13, patientName: 'Kartini Salleh', appointmentType: 'Routine Check-up', sessionType: 'TREATMENT', date: '2020-03-28', time: '4:30 PM', visitType: 'Virtual', status: 'Scheduled', notes: 'NOTE', isToday: false },
+  { id: 14, patientName: 'Ismail bin Yusof', appointmentType: 'Follow Up', sessionType: 'FOLLOW UP', date: '2020-03-29', time: '8:00 AM', visitType: 'In-person', status: 'Scheduled', notes: '', isToday: false },
+  { id: 15, patientName: 'Nur Izzati', appointmentType: 'Consultation', sessionType: 'TREATMENT', date: '2020-03-29', time: '9:30 AM', visitType: 'Virtual', status: 'Scheduled', notes: '', isToday: false },
+]
 
 // Available time slots
 const TIME_SLOTS = ['8:00 AM', '9:30 AM', '11:00 AM', '12:30 PM', '3:00 PM', '4:30 PM']
 
-const ITEMS_PER_PAGE = 5
-
-export const useAppointments = () => {
-  // Data & loading states
-  const [appointments, setAppointments] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
-
-  // Pagination & filtering
-  const [todayPage, setTodayPage] = useState(1)
-  const [upcomingPage, setUpcomingPage] = useState(1)
-  const [totalTodayCount, setTotalTodayCount] = useState(0)
-  const [totalUpcomingCount, setTotalUpcomingCount] = useState(0)
-
+export const useAppointments = (itemsPerPage = 5) => {
+  // State
+  const [appointments, setAppointments] = useState(initialAppointments)
   const [searchQuery, setSearchQuery] = useState('')
   const [filterOptions, setFilterOptions] = useState({
     appointmentType: '',
     visitType: ''
   })
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' })
+  const [todayPage, setTodayPage] = useState(1)
+  const [upcomingPage, setUpcomingPage] = useState(1)
 
-  // Helpers
-  const isToday = (dt) => {
-    const t = new Date(dt)
-    const n = new Date()
-    return t.getFullYear() === n.getFullYear() && t.getMonth() === n.getMonth() && t.getDate() === n.getDate()
-  }
+  // Separate today and upcoming appointments
+  const todayAppointments = useMemo(() => {
+    return appointments.filter(apt => apt.isToday)
+  }, [appointments])
 
-  // Fetch both today & upcoming from API
-  const fetchAppointments = useCallback(async (date, page = 1, filters = {}) => {
-    setLoading(true)
-    setError(null)
-    try {
-      const params = new URLSearchParams({
-        date,
-        page: page.toString(),
-        limit: ITEMS_PER_PAGE.toString()
-      })
-      if (filters.appointmentType) params.set('appointmentType', filters.appointmentType)
-      if (filters.visitType) params.set('visitType', filters.visitType)
+  const upcomingAppointments = useMemo(() => {
+    return appointments.filter(apt => !apt.isToday)
+  }, [appointments])
 
-      const data = await appointmentApi.getAll(`?${params.toString()}`)
+  // Filter appointments based on search and filters
+  const filterAppointments = useCallback((appointmentList) => {
+    return appointmentList.filter(apt => {
+      const matchesSearch = !searchQuery || 
+        apt.patientName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        apt.time.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        apt.status.toLowerCase().includes(searchQuery.toLowerCase())
+      
+      const matchesType = !filterOptions.appointmentType || 
+        apt.appointmentType === filterOptions.appointmentType
+      
+      const matchesVisit = !filterOptions.visitType || 
+        apt.visitType === filterOptions.visitType
 
-      if (Array.isArray(data)) {
-        // Simple array fallback
-        return data
-      } else if (data && data.data) {
-        // Paginated structure
-        return data.data
+      return matchesSearch && matchesType && matchesVisit
+    })
+  }, [searchQuery, filterOptions])
+
+  // Sort appointments
+  const sortAppointments = useCallback((appointmentList) => {
+    if (!sortConfig.key) return appointmentList
+
+    return [...appointmentList].sort((a, b) => {
+      let aVal = a[sortConfig.key]
+      let bVal = b[sortConfig.key]
+
+      if (sortConfig.key === 'time') {
+        // Convert time to comparable format
+        const parseTime = (t) => {
+          const [time, period] = t.split(' ')
+          let [hours, minutes] = time.split(':').map(Number)
+          if (period === 'PM' && hours !== 12) hours += 12
+          if (period === 'AM' && hours === 12) hours = 0
+          return hours * 60 + minutes
+        }
+        aVal = parseTime(aVal)
+        bVal = parseTime(bVal)
       }
-      return []
-    } catch (err) {
-      console.error('Appointment fetch error:', err)
-      setError(err.message || 'Could not fetch appointments')
-      return []
-    } finally {
-      setLoading(false)
-    }
+
+      if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1
+      if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1
+      return 0
+    })
+  }, [sortConfig])
+
+  // Filtered and sorted appointments
+  const filteredTodayAppointments = useMemo(() => {
+    return sortAppointments(filterAppointments(todayAppointments))
+  }, [todayAppointments, filterAppointments, sortAppointments])
+
+  const filteredUpcomingAppointments = useMemo(() => {
+    return sortAppointments(filterAppointments(upcomingAppointments))
+  }, [upcomingAppointments, filterAppointments, sortAppointments])
+
+  // Pagination
+  const paginatedTodayAppointments = useMemo(() => {
+    const startIndex = (todayPage - 1) * itemsPerPage
+    return filteredTodayAppointments.slice(startIndex, startIndex + itemsPerPage)
+  }, [filteredTodayAppointments, todayPage, itemsPerPage])
+
+  const paginatedUpcomingAppointments = useMemo(() => {
+    const startIndex = (upcomingPage - 1) * itemsPerPage
+    return filteredUpcomingAppointments.slice(startIndex, startIndex + itemsPerPage)
+  }, [filteredUpcomingAppointments, upcomingPage, itemsPerPage])
+
+  const todayTotalPages = Math.ceil(filteredTodayAppointments.length / itemsPerPage)
+  const upcomingTotalPages = Math.ceil(filteredUpcomingAppointments.length / itemsPerPage)
+
+  // Actions
+  const addAppointment = useCallback((appointmentData) => {
+    const newId = Math.max(...appointments.map(a => a.id)) + 1
+    setAppointments(prev => [...prev, { ...appointmentData, id: newId }])
+    return newId
+  }, [appointments])
+
+  const updateAppointment = useCallback((id, updates) => {
+    setAppointments(prev => 
+      prev.map(apt => apt.id === id ? { ...apt, ...updates } : apt)
+    )
   }, [])
 
-  // Fetch today and upcoming separately
-  const loadAppointments = useCallback(async () => {
-    const todayStr = (new Date()).toISOString().slice(0,10) // 'YYYY-MM-DD'
-
-    const todayList = await fetchAppointments(todayStr, todayPage, filterOptions)
-    const upcomingList = await fetchAppointments('future', upcomingPage, filterOptions)
-
-    setAppointments([...todayList, ...upcomingList])
-    setTotalTodayCount(todayList.length)
-    setTotalUpcomingCount(upcomingList.length)
-  }, [todayPage, upcomingPage, filterOptions, fetchAppointments])
-
-  // CRUD helpers
-  const addAppointment = useCallback(async (appointmentData) => {
-    try {
-      const newAppt = await appointmentApi.create(appointmentData)
-      await loadAppointments()
-      return newAppt
-    } catch (err) {
-      setError(err.message || 'Could not create appointment')
-      throw err
-    }
-  }, [loadAppointments])
-
-  const updateAppointment = useCallback(async (id, updates) => {
-    try {
-      await appointmentApi.update(id, updates)
-      setAppointments(prev =>
-        prev.map(apt => apt.id === id ? { ...apt, ...updates } : apt)
-      )
-    } catch (err) {
-      setError(err.message || 'Could not update appointment')
-      throw err
-    }
+  const deleteAppointment = useCallback((id) => {
+    setAppointments(prev => prev.filter(apt => apt.id !== id))
   }, [])
 
-  const deleteAppointment = useCallback(async (id) => {
-    try {
-      await appointmentApi.delete(id)
-      setAppointments(prev => prev.filter(apt => apt.id !== id))
-      setTotalTodayCount(prev => prev - 1)
-      setTotalUpcomingCount(prev => prev - 1)
-    } catch (err) {
-      setError(err.message || 'Could not delete appointment')
-      throw err
-    }
-  }, [])
-
-  const updateStatus = useCallback(async (id, newStatus) => {
-    await updateAppointment(id, { status: newStatus })
+  const updateStatus = useCallback((id, newStatus) => {
+    updateAppointment(id, { status: newStatus })
   }, [updateAppointment])
 
   const getAppointmentById = useCallback((id) => {
@@ -127,43 +145,90 @@ export const useAppointments = () => {
   }, [appointments])
 
   const getAppointmentsByPatientName = useCallback((patientName) => {
-    return appointments.filter(apt =>
-      apt.patientName && apt.patientName.toLowerCase() === patientName.toLowerCase()
+    return appointments.filter(apt => 
+      apt.patientName.toLowerCase() === patientName.toLowerCase()
     )
   }, [appointments])
 
+  // Get available time slots for a given date
   const getAvailableTimeSlots = useCallback((date) => {
-    // If backend offers /appointments/conflicts?date=... use it; otherwise fall back to client-side calc
-    const booked = appointments.filter(apt => apt.date === date).map(a => a.time)
-    return TIME_SLOTS.filter(slot => !booked.includes(slot))
+    const bookedSlots = appointments
+      .filter(apt => apt.date === date)
+      .map(apt => apt.time)
+    return TIME_SLOTS.filter(slot => !bookedSlots.includes(slot))
   }, [appointments])
 
+  // Handle search with pagination reset
+  const handleSearch = useCallback((query) => {
+    setSearchQuery(query)
+    setTodayPage(1)
+    setUpcomingPage(1)
+  }, [])
+
+  // Handle filter with pagination reset
+  const handleFilter = useCallback((options) => {
+    setFilterOptions(options)
+    setTodayPage(1)
+    setUpcomingPage(1)
+  }, [])
+
+  // Handle sort
+  const handleSort = useCallback((key) => {
+    setSortConfig(prev => ({
+      key,
+      direction: prev.key === key && prev.direction === 'asc' ? 'desc' : 'asc'
+    }))
+  }, [])
+
+  // Generate CSV data
+  const generateCSV = useCallback((appointmentList) => {
+    const headers = ['Patient Name', 'Contact Number', 'Appointment Type', 'Date', 'Time', 'Visit Type', 'Status']
+    const rows = appointmentList.map(apt => [
+      apt.patientName,
+      apt.contactNumber || 'N/A',
+      apt.appointmentType,
+      apt.date,
+      apt.time,
+      apt.visitType,
+      apt.status
+    ])
+    
+    const csvContent = [headers, ...rows]
+      .map(row => row.join(','))
+      .join('\n')
+    
+    return csvContent
+  }, [])
+
   return {
-    loading,
-    error,
-    appointments: appointments,
-    todayCount: totalTodayCount,
-    upcomingCount: totalUpcomingCount,
+    // Data
+    todayAppointments: paginatedTodayAppointments,
+    upcomingAppointments: paginatedUpcomingAppointments,
+    allTodayAppointments: filteredTodayAppointments,
+    allUpcomingAppointments: filteredUpcomingAppointments,
+    allAppointments: appointments,
+    
+    // Pagination - Today
     todayPage,
+    todayTotalPages,
+    todayCount: filteredTodayAppointments.length,
     setTodayPage,
+    
+    // Pagination - Upcoming
     upcomingPage,
+    upcomingTotalPages,
+    upcomingCount: filteredUpcomingAppointments.length,
     setUpcomingPage,
+    
+    // Filters & Sort
     searchQuery,
-    setSearchQuery (query) {
-      setSearchQuery(query)
-      setTodayPage(1)
-      setUpcomingPage(1)
-    },
     filterOptions,
-    setFilterOptions (opts) {
-      setFilterOptions(opts)
-      setTodayPage(1)
-      setUpcomingPage(1)
-    },
     sortConfig,
-    setSortConfig,
-    // actions
-    loadAppointments,
+    setSearchQuery: handleSearch,
+    setFilterOptions: handleFilter,
+    handleSort,
+    
+    // Actions
     addAppointment,
     updateAppointment,
     deleteAppointment,
@@ -171,7 +236,12 @@ export const useAppointments = () => {
     getAppointmentById,
     getAppointmentsByPatientName,
     getAvailableTimeSlots,
+    generateCSV,
+    
+    // Constants
+    timeSlots: TIME_SLOTS,
   }
 }
 
 export default useAppointments
+

--- a/Jejakra-web/src/hooks/usePatients.js
+++ b/Jejakra-web/src/hooks/usePatients.js
@@ -1,154 +1,142 @@
 /**
  * Custom Hook: usePatients
- * Manages patient data, filtering, and states with live API calls
+ * Manages patient data, filtering, and actions
  */
 
-import { useState, useEffect, useCallback } from 'react'
-import { patientApi } from '../services/api'
+import { useState, useMemo, useCallback } from 'react'
+import { formatDate } from '../utils/formatters'
 
-const ITEMS_PER_PAGE = 10
+// Initial mock patient data
+const initialPatientsData = {
+  1: { name: 'Ahmad bin Abdullah', gender: 'Male', age: '45', address: 'No. 12, Jalan Ampang, 50450 Kuala Lumpur', registeredDate: '2020-01-15', lastVisit: '2024-01-08', lastVisitTime: '10:30 AM', nextAppointment: '2024-02-15', disease: 'Hypertension', contactNumber: '012-345-6701', status: 'Active' },
+  2: { name: 'Siti Nurhaliza', gender: 'Female', age: '38', address: 'No. 45, Taman Tun Dr Ismail, 60000 Kuala Lumpur', registeredDate: '2019-11-20', lastVisit: '2024-01-05', lastVisitTime: '2:00 PM', nextAppointment: '2024-02-10', disease: 'Diabetes Type 2', contactNumber: '012-345-6702', status: 'Active' },
+  3: { name: 'Muhammad Faiz', gender: 'Male', age: '52', address: 'No. 78, Bangsar South, 59200 Kuala Lumpur', registeredDate: '2020-02-10', lastVisit: '2024-01-02', lastVisitTime: '9:00 AM', nextAppointment: '2024-02-20', disease: 'Anxiety Disorder', contactNumber: '012-345-6703', status: 'Active' },
+  4: { name: 'Nurul Ain', gender: 'Female', age: '34', address: 'No. 23, Jalan SS2/55, 47300 Petaling Jaya, Selangor', registeredDate: '2019-12-05', lastVisit: '2023-08-15', lastVisitTime: '11:30 AM', nextAppointment: null, disease: 'Chronic Pain', contactNumber: '012-345-6704', status: 'Inactive' },
+  5: { name: 'Amirul Haziq', gender: 'Male', age: '29', address: 'No. 56, Seksyen 7, 40000 Shah Alam, Selangor', registeredDate: '2020-03-01', lastVisit: '2024-01-06', lastVisitTime: '3:30 PM', nextAppointment: '2024-02-08', disease: 'Asthma', contactNumber: '012-345-6705', status: 'Active' },
+  6: { name: 'Fatimah Zahra', gender: 'Female', age: '41', address: 'No. 89, USJ 1, 47600 Subang Jaya, Selangor', registeredDate: '2019-10-12', lastVisit: null, lastVisitTime: null, nextAppointment: '2024-02-12', disease: 'Migraine', contactNumber: '012-345-6706', status: 'New' },
+  7: { name: 'Hafiz Rahman', gender: 'Male', age: '36', address: 'No. 34, Taman Molek, 81100 Johor Bahru, Johor', registeredDate: '2020-01-25', lastVisit: '2024-01-03', lastVisitTime: '4:00 PM', nextAppointment: '2024-02-18', disease: 'Arthritis', contactNumber: '012-345-6707', status: 'Active' },
+  8: { name: 'Aisyah Putri', gender: 'Female', age: '42', address: 'No. 67, Jalan Penang, 10050 George Town, Penang', registeredDate: '2019-09-18', lastVisit: null, lastVisitTime: null, nextAppointment: null, disease: 'Gastritis', contactNumber: '012-345-6708', status: 'Pending' },
+  9: { name: 'Rizal bin Hassan', gender: 'Male', age: '39', address: 'No. 90, Jalan Ipoh, 51200 Kuala Lumpur', registeredDate: '2020-02-28', lastVisit: '2024-01-07', lastVisitTime: '10:00 AM', nextAppointment: '2024-02-25', disease: 'Insomnia', contactNumber: '012-345-6709', status: 'Active' },
+  10: { name: 'Nadia Tan', gender: 'Female', age: '48', address: 'No. 15, Damansara Heights, 50490 Kuala Lumpur', registeredDate: '2019-08-22', lastVisit: '2023-06-20', lastVisitTime: '1:30 PM', nextAppointment: null, disease: 'Obesity', contactNumber: '012-345-6710', status: 'Inactive' },
+  11: { name: 'Kelvin Wong', gender: 'Male', age: '55', address: 'No. 28, Bukit Bintang, 55100 Kuala Lumpur', registeredDate: '2019-07-14', lastVisit: '2024-01-04', lastVisitTime: '11:00 AM', nextAppointment: '2024-02-22', disease: 'Heart Disease', contactNumber: '012-345-6711', status: 'Active' },
+  12: { name: 'Michelle Lee', gender: 'Female', age: '50', address: 'No. 41, Mont Kiara, 50480 Kuala Lumpur', registeredDate: '2020-01-08', lastVisit: '2022-12-10', lastVisitTime: '9:30 AM', nextAppointment: null, disease: 'Fibromyalgia', contactNumber: '012-345-6712', status: 'Archived' },
+  13: { name: 'Priya Kumari', gender: 'Female', age: '40', address: 'No. 54, Brickfields, 50470 Kuala Lumpur', registeredDate: '2019-06-30', lastVisit: '2024-01-01', lastVisitTime: '2:30 PM', nextAppointment: '2024-02-05', disease: 'Allergies', contactNumber: '012-345-6713', status: 'Active' },
+  14: { name: 'Ravi Kumar', gender: 'Male', age: '31', address: 'No. 77, Klang, 41150 Selangor', registeredDate: '2020-03-10', lastVisit: null, lastVisitTime: null, nextAppointment: '2024-02-14', disease: 'GERD', contactNumber: '012-345-6714', status: 'New' },
+  15: { name: 'Sarah Abdullah', gender: 'Female', age: '33', address: 'No. 100, Cyberjaya, 63000 Selangor', registeredDate: '2019-11-05', lastVisit: '2023-12-28', lastVisitTime: '4:30 PM', nextAppointment: '2024-02-28', disease: 'Stress Disorder', contactNumber: '012-345-6715', status: 'Active' }
+}
 
-export const usePatients = () => {
-  const [patients, setPatients] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
-
-  // Pagination & filtering state
-  const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
-  const [totalCount, setTotalCount] = useState(0)
-  
+export const usePatients = (itemsPerPage = 10) => {
+  // State
+  const [patients, setPatients] = useState(initialPatientsData)
   const [searchQuery, setSearchQuery] = useState('')
   const [genderFilter, setGenderFilter] = useState('All')
   const [statusFilter, setStatusFilter] = useState('All')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [selectedPatient, setSelectedPatient] = useState(null)
 
-  // Fetch patients with optional paging / filtering
-  const fetchPatients = useCallback(async (pageNumber = 1, filters = {}) => {
-    setLoading(true)
-    setError(null)
-    try {
-      const params = new URLSearchParams({ page: pageNumber.toString(), limit: ITEMS_PER_PAGE.toString() })
-      if (filters.search) params.set('search', filters.search)
-      if (filters.gender && filters.gender !== 'All') params.set('gender', filters.gender)
-      if (filters.status && filters.status !== 'All') params.set('status', filters.status)
+  // Convert patients object to array with IDs
+  const patientsArray = useMemo(() => {
+    return Object.entries(patients).map(([id, patient]) => ({
+      id: parseInt(id),
+      ...patient
+    }))
+  }, [patients])
 
-      const response = await patientApi.getAll(`?${params.toString()}`)
+  // Filter patients based on search and filters
+  const filteredPatients = useMemo(() => {
+    return patientsArray.filter(patient => {
+      const matchesSearch = !searchQuery || 
+        patient.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        `P-${String(patient.id).padStart(4, '0')}`.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        patient.status.toLowerCase().includes(searchQuery.toLowerCase())
+      
+      const matchesGender = genderFilter === 'All' || patient.gender === genderFilter
+      const matchesStatus = statusFilter === 'All' || patient.status === statusFilter
 
-      if (Array.isArray(response)) {
-        // If array returned (fallback route), set directly
-        setPatients(response)
-        setTotalPages(Math.ceil(response.length / ITEMS_PER_PAGE))
-        setTotalCount(response.length)
-      } else if (response && response.data) {
-        // Paginated API format
-        setPatients(response.data)
-        setTotalPages(response.totalPages || Math.ceil(response.total / response.limit))
-        setTotalCount(response.total)
-      } else if (Array.isArray(response.results)) {
-        // Alternate format
-        setPatients(response.results)
-        setTotalCount(response.total)
-        setTotalPages(Math.ceil(response.total / ITEMS_PER_PAGE))
-      }
-    } catch (err) {
-      console.error('Could not fetch patients:', err)
-      setError(err.message || 'Failed to fetch patients')
-    } finally {
-      setLoading(false)
-    }
+      return matchesSearch && matchesGender && matchesStatus
+    })
+  }, [patientsArray, searchQuery, genderFilter, statusFilter])
+
+  // Pagination
+  const totalPages = Math.ceil(filteredPatients.length / itemsPerPage)
+  const paginatedPatients = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage
+    return filteredPatients.slice(startIndex, startIndex + itemsPerPage)
+  }, [filteredPatients, currentPage, itemsPerPage])
+
+  // Actions
+  const addPatient = useCallback((patientData) => {
+    const newId = Math.max(...Object.keys(patients).map(Number)) + 1
+    setPatients(prev => ({
+      ...prev,
+      [newId]: patientData
+    }))
+    return newId
+  }, [patients])
+
+  const updatePatient = useCallback((id, updates) => {
+    setPatients(prev => ({
+      ...prev,
+      [id]: { ...prev[id], ...updates }
+    }))
   }, [])
 
-  // CRUD helpers — call API endpoints & re-load data
-  const addPatient = useCallback(async (patientData) => {
-    try {
-      await patientApi.create(patientData)
-      await fetchPatients(1) // refresh to first page
-    } catch (err) {
-      console.error('Could not create patient:', err)
-      setError(err.message || 'Could not create patient')
-      throw err
-    }
-  }, [fetchPatients])
-
-  const updatePatient = useCallback(async (id, updates) => {
-    try {
-      await patientApi.update(id, updates)
-      setPatients(prev => prev.map(p => p.id === id ? { ...p, ...updates } : p))
-    } catch (err) {
-      console.error('Could not update patient:', err)
-      setError(err.message || 'Could not update patient')
-      throw err
-    }
+  const deletePatient = useCallback((id) => {
+    setPatients(prev => {
+      const { [id]: removed, ...rest } = prev
+      return rest
+    })
   }, [])
 
-  const deletePatient = useCallback(async (id) => {
-    try {
-      await patientApi.delete(id)
-      setPatients(prev => prev.filter(p => p.id !== id))
-      setTotalCount(prev => prev - 1)
-    } catch (err) {
-      console.error('Could not delete patient:', err)
-      setError(err.message || 'Could not delete patient')
-      throw err
-    }
-  }, [])
+  const getPatientById = useCallback((id) => {
+    return patients[id] ? { id: parseInt(id), ...patients[id] } : null
+  }, [patients])
 
-  const getPatientById = useCallback(async (id) => {
-    try {
-      return await patientApi.getById(id)
-    } catch (err) {
-      console.error('Could not get patient:', err)
-      return null
-    }
-  }, [])
-
-  // Handle search / filter resets
+  // Reset pagination when filters change
   const handleSearch = useCallback((query) => {
     setSearchQuery(query)
-    setPage(1)
-    fetchPatients(1, { search: query, gender: genderFilter, status: statusFilter })
-  }, [genderFilter, statusFilter, fetchPatients])
-
-  const handleFilter = useCallback((filters) => {
-    if ('gender' in filters) setGenderFilter(filters.gender)
-    if ('status' in filters) setStatusFilter(filters.status)
-    setPage(1)
-    fetchPatients(1, { search: searchQuery, gender: filters.gender || genderFilter, status: filters.status || statusFilter })
-  }, [searchQuery, genderFilter, statusFilter, fetchPatients])
-
-  const getAvailableTimeSlots = useCallback(async (patientId, date) => {
-    // placeholder if backend ever offers /patients/:id/slots?date=... use it here
-    return []
+    setCurrentPage(1)
   }, [])
 
-  // Load on mount and when page changes
-  useEffect(() => {
-    fetchPatients(page, { search: searchQuery, gender: genderFilter, status: statusFilter })
-  }, [page, searchQuery, genderFilter, statusFilter, fetchPatients])
+  const handleGenderFilter = useCallback((gender) => {
+    setGenderFilter(gender)
+    setCurrentPage(1)
+  }, [])
+
+  const handleStatusFilter = useCallback((status) => {
+    setStatusFilter(status)
+    setCurrentPage(1)
+  }, [])
 
   return {
-    // Data and meta
-    patients,
-    loading,
-    error,
-    totalCount,
+    // Data
+    patients: paginatedPatients,
+    allPatients: patientsArray,
+    filteredPatients,
+    selectedPatient,
+    
     // Pagination
-    page,
+    currentPage,
     totalPages,
-    setPage,
-    // UI handlers
+    totalCount: filteredPatients.length,
+    setCurrentPage,
+    
+    // Filters
     searchQuery,
     genderFilter,
     statusFilter,
-    handleSearch,
-    handleFilter,
+    setSearchQuery: handleSearch,
+    setGenderFilter: handleGenderFilter,
+    setStatusFilter: handleStatusFilter,
+    
     // Actions
     addPatient,
     updatePatient,
     deletePatient,
     getPatientById,
-    getAvailableTimeSlots,
+    setSelectedPatient,
   }
 }
 
 export default usePatients
+

--- a/Jejakra-web/src/services/auth.js
+++ b/Jejakra-web/src/services/auth.js
@@ -3,7 +3,6 @@
  * Handles user authentication and session management
  */
 
-import * as api from './api'
 import * as storage from './storage'
 
 const AUTH_TOKEN_KEY = 'auth_token'


### PR DESCRIPTION
Reverts getexp-wtf/Jejakra-#5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because these hooks’ public return shapes and behaviors change significantly, which can break screens relying on previous API-backed fields (e.g., `loading/error/loadAppointments` and count semantics). Data is now non-persistent and fully client-side, reducing backend risk but increasing UI integration risk.
> 
> **Overview**
> Reverts `useAppointments` and `usePatients` from live API-driven data fetching (loading/error state, pagination via backend, CRUD via `appointmentApi`/`patientApi`) to **in-memory mock datasets** with client-side filtering, sorting, and pagination.
> 
> `useAppointments` now seeds with static appointments, derives today/upcoming lists, adds client-side sort (including time parsing), and introduces `generateCSV`; exported hook shape changes to return paginated lists plus `all*` collections and handler-style setters. `usePatients` similarly switches to a local patient map, adds client-side search/gender/status filtering and pagination, and exposes `selectedPatient` management.
> 
> Also removes the unused API import from `services/auth.js` (auth remains storage-backed mock logic).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba115d8fa8c481b41201f2eac306e14d7b3372c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->